### PR TITLE
Mark bundle as ezplatform-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "kaliop/identitymanagementbundle",
   "description": "Kaliop Identity Management Bundle",
+  "type": "ezplatform-bundle",
   "license": "GPL-2.0",
   "authors": [
     {


### PR DESCRIPTION
Makes it possible to query ezplatform bundles via packagist: https://packagist.org/packages/list.json?type=ezplatform-bundle
